### PR TITLE
Fix broken links in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ This repository automates numerous workflows:
 On push to `main`, all tests in the `tests` directory are automatically run. Currently, MOCCA2 is tested on Ubuntu with Python 3.10, 3.11 and 3.12.
 
 ### Docs
-On push to `main`, the Sphinx docs are automatically compiled and published to [GitHub pages](https://bayer-group.github.io/mocca).
+On push to `main`, the Sphinx docs are automatically compiled and published to [GitHub pages](https://bayer-group.github.io/MOCCA).
 
 ### Example data
 The repository contains various example datasets:

--- a/src/mocca2/example_data/data/README.md
+++ b/src/mocca2/example_data/data/README.md
@@ -4,7 +4,7 @@ The archives in this branch contain various example chromatogram datasets.
 
 You can use them from mocca2 package using `mocca2.example_data` module after downloading them using `python -m mocca2 --download-data`.
 
-See detailed documentation in the [docs](https://oboril.github.io/MOCCA/ref_example_data.html).
+See detailed documentation in the [docs](https://bayer-group.github.io/MOCCA/ref_example_data.html).
 
 ## Datasets
 


### PR DESCRIPTION
- GitHub Page URLs are case-sensitive, so `/mocca` doesn't work
- Replaced a link that led to the old GitHub Pages