### PR TITLE
Reference MOCCA+Peaksel combination to support raw files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 MOCCA2 is a Python package for automatic processing of HPLC chromatograms.
 
 To automate your workflow and get accurate results, MOCCA2 features:
- - support for raw data files from Agilent, Shimadzu and Waters
+ - support for text export files from Agilent, Shimadzu and Waters (to read raw vendor formats, use [Peaksel SDK](https://github.com/elsci-io/peaksel-sdk/blob/master/python/doc/mocca-integration.md))
  - automatic baseline correction
  - adaptive peak picking
  - automatic purity checking and peak deconvolution


### PR DESCRIPTION
Just added integration between MOCCA & Peaksel SDK: https://github.com/elsci-io/peaksel-sdk/blob/master/python/doc/mocca-integration.md

Previously, the documentation was a little confusing - it mentioned that raw files can be parsed from some HPLC vendors, while in fact only text exports were supported.

Now, mentioning explicitly both text and raw parsing.