### PR TITLE
Diagram visualization of the MOCCA codebase

### DIFF
--- a/.codeboarding/Chromatogram Processing.md
+++ b/.codeboarding/Chromatogram Processing.md
@@ -1,0 +1,130 @@
+```mermaid
+graph LR
+    Chromatogram_Processing["Chromatogram Processing"]
+    Baseline_Estimation["Baseline Estimation"]
+    Peak_Detection_and_Manipulation["Peak Detection and Manipulation"]
+    Deconvolution_Algorithms["Deconvolution Algorithms"]
+    Spectral_Guessing["Spectral Guessing"]
+    Non_Negative_Least_Squares_NNLS_Solver["Non-Negative Least Squares (NNLS) Solver"]
+    Peak_Modeling["Peak Modeling"]
+    Core_Data_Models["Core Data Models"]
+    Chromatogram_Processing -- "invokes" --> Baseline_Estimation
+    Chromatogram_Processing -- "invokes" --> Peak_Detection_and_Manipulation
+    Chromatogram_Processing -- "invokes" --> Deconvolution_Algorithms
+    Chromatogram_Processing -- "manages" --> Core_Data_Models
+    Deconvolution_Algorithms -- "utilizes" --> Peak_Modeling
+    Deconvolution_Algorithms -- "utilizes" --> Non_Negative_Least_Squares_NNLS_Solver
+    Deconvolution_Algorithms -- "utilizes" --> Spectral_Guessing
+    Peak_Detection_and_Manipulation -- "creates" --> Core_Data_Models
+    Spectral_Guessing -- "depends on" --> Peak_Detection_and_Manipulation
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the architecture of the Chromatogram Processing subsystem, which is central to analyzing chromatographic data. The main flow involves the 'Chromatogram Processing' component orchestrating baseline correction, peak detection, and deconvolution. It leverages specialized components like 'Baseline Estimation' for noise removal, 'Peak Detection and Manipulation' for identifying and refining peaks, and 'Deconvolution Algorithms' for resolving overlapping peaks. The deconvolution process further relies on 'Peak Modeling' for mathematical representations of peaks, 'Spectral Guessing' for initial spectral estimations, and 'Non-Negative Least Squares (NNLS) Solver' for concentration and spectra calculations. All these operations interact with 'Core Data Models' to manage the fundamental data structures of the system.
+
+### Chromatogram Processing
+This component acts as the central orchestrator for processing individual chromatograms. It manages the overall workflow, including baseline correction, peak detection, and deconvolution, by interacting with specialized sub-components. It also handles the creation and management of Peak and DeconvolvedPeak objects.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram` (27:579)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L100-L145" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram:correct_baseline` (100:145)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L147-L229" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram:find_peaks` (147:229)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L231-L295" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram:deconvolve_peaks` (231:295)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L401-L473" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram:refine_peaks` (401:473)</a>
+
+
+### Baseline Estimation
+This component is responsible for estimating and correcting the baseline of chromatographic data. It provides various algorithms to remove signal drift and noise.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/wrapper.py#L16-L98" target="_blank" rel="noopener noreferrer">`mocca2.baseline.wrapper.estimate_baseline` (16:98)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/arpls.py#L17-L147" target="_blank" rel="noopener noreferrer">`mocca2.baseline.arpls.arpls` (17:147)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/asls.py#L15-L129" target="_blank" rel="noopener noreferrer">`mocca2.baseline.asls.asls` (15:129)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/flatfit.py#L16-L76" target="_blank" rel="noopener noreferrer">`mocca2.baseline.flatfit.flatfit` (16:76)</a>
+
+
+### Peak Detection and Manipulation
+This component handles the identification, splitting, and merging of peaks in the chromatogram. It ensures accurate delineation of individual chromatographic events.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/find_peaks.py#L13-L101" target="_blank" rel="noopener noreferrer">`mocca2.peaks.find_peaks.find_peaks` (13:101)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/find_peaks.py#L104-L134" target="_blank" rel="noopener noreferrer">`mocca2.peaks.find_peaks._initial_peak_picking` (104:134)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/split.py#L8-L33" target="_blank" rel="noopener noreferrer">`mocca2.peaks.split.split_peaks` (8:33)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/split.py#L35-L85" target="_blank" rel="noopener noreferrer">`mocca2.peaks.split._split_peak` (35:85)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/merge_overlapping.py#L7-L40" target="_blank" rel="noopener noreferrer">`mocca2.peaks.merge_overlapping.merge_overlapping_peaks` (7:40)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/merge_overlapping.py#L49-L60" target="_blank" rel="noopener noreferrer">`mocca2.peaks.merge_overlapping._merge_two_peaks` (49:60)</a>
+
+
+### Deconvolution Algorithms
+This component provides the core algorithms for deconvolving complex chromatographic peaks into their underlying individual components. It includes adaptive and fixed deconvolution strategies and methods for fitting peak models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/deconvolve.py#L11-L74" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.deconvolve.deconvolve_adaptive` (11:74)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/deconvolve.py#L77-L126" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.deconvolve.deconvolve_fixed` (77:126)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/fit_peak_model.py#L20-L264" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.fit_peak_model.fit_peak_model` (20:264)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/alternating_lstsq.py#L12-L105" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.alternating_lstsq.alternating_lstsq` (12:105)</a>
+
+
+### Spectral Guessing
+This component is responsible for generating initial guesses for spectra during the deconvolution process, often using similarity metrics.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/guess_spectra.py#L11-L54" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.guess_spectra.guess_spectra` (11:54)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/guess_spectra.py#L57-L69" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.guess_spectra._get_similarity_matrix` (57:69)</a>
+
+
+### Non-Negative Least Squares (NNLS) Solver
+This component provides mathematical routines for solving non-negative least squares problems, crucial for estimating concentrations and spectra during deconvolution.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/nonnegative_lstsq.py#L11-L53" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.nonnegative_lstsq.concentrations_from_spectra` (11:53)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/nonnegative_lstsq.py#L56-L83" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.nonnegative_lstsq.spectra_from_concentrations` (56:83)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/nnls.py#L8-L70" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.nnls.nnls` (8:70)</a>
+
+
+### Peak Modeling
+This component defines and implements various mathematical models used to describe the characteristic shapes of chromatographic peaks, utilized by the deconvolution process.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L14-L53" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.PeakModel` (14:53)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L17-L21" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.PeakModel:__call__` (17:21)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L240-L329" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.Bemg` (240:329)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L246-L266" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.Bemg:val` (246:266)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L268-L310" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.Bemg:grad` (268:310)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L80-L115" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.BiGaussian` (80:115)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L118-L167" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.BiGaussianTailing` (118:167)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L170-L230" target="_blank" rel="noopener noreferrer">`mocca2.deconvolution.peak_models.FraserSuzuki` (170:230)</a>
+
+
+### Core Data Models
+This component defines the fundamental data structures used throughout the system, representing 2D chromatographic data, peaks, deconvolved peaks, components, and compounds.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`mocca2.classes.data2d.Data2D` (13:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L9-L67" target="_blank" rel="noopener noreferrer">`mocca2.classes.peak.Peak` (9:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L11-L142" target="_blank" rel="noopener noreferrer">`mocca2.classes.deconvolved_peak.DeconvolvedPeak` (11:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L10-L73" target="_blank" rel="noopener noreferrer">`mocca2.classes.component.Component` (10:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L12-L94" target="_blank" rel="noopener noreferrer">`mocca2.classes.compound.Compound` (12:94)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core Data Structures.md
+++ b/.codeboarding/Core Data Structures.md
@@ -1,0 +1,164 @@
+```mermaid
+graph LR
+    Data2D["Data2D"]
+    Chromatogram["Chromatogram"]
+    PeakRepresentation["PeakRepresentation"]
+    Component["Component"]
+    Compound["Compound"]
+    MoccaDataset["MoccaDataset"]
+    DataParsers["DataParsers"]
+    PeakProcessing["PeakProcessing"]
+    Clustering["Clustering"]
+    Serialization["Serialization"]
+    DataParsers -- "Creates" --> Data2D
+    Chromatogram -- "Extends" --> Data2D
+    Chromatogram -- "Processes" --> Data2D
+    Chromatogram -- "Utilizes" --> PeakProcessing
+    Chromatogram -- "Generates" --> PeakRepresentation
+    PeakRepresentation -- "References" --> Data2D
+    PeakRepresentation -- "Comprises" --> Component
+    Component -- "Forms" --> Compound
+    MoccaDataset -- "Manages" --> Chromatogram
+    MoccaDataset -- "Processes" --> Chromatogram
+    MoccaDataset -- "Manages" --> Compound
+    MoccaDataset -- "Orchestrates" --> Clustering
+    MoccaDataset -- "Manages Raw Data" --> Data2D
+    Serialization -- "Serializes" --> Data2D
+    Serialization -- "Serializes" --> Chromatogram
+    Serialization -- "Serializes" --> PeakRepresentation
+    Serialization -- "Serializes" --> Component
+    Serialization -- "Serializes" --> Compound
+    Serialization -- "Serializes" --> MoccaDataset
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph describes the core data structures and their interactions within the MOCCA system, focusing on how chromatographic data is represented, processed, and managed. It illustrates the hierarchy from raw 2D data to derived entities like peaks, components, and compounds, and how these structures are handled by various processing and management components. The main flow involves parsing raw data into Data2D objects, which are then processed into Chromatogram objects. These Chromatograms undergo peak detection and deconvolution, leading to PeakRepresentation, Component, and Compound entities. A central MoccaDataset manages collections of Chromatograms and Compounds, orchestrating the overall data analysis pipeline, while a Serialization component handles data persistence.
+
+### Data2D
+The Data2D component is the fundamental data structure for representing two-dimensional chromatographic data, typically absorbance over time and wavelength. It provides core functionalities for data manipulation such as extracting specific time or wavelength ranges, interpolating data, and performing arithmetic operations. It also includes methods for plotting and serialization.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D` (13:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L28-L30" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:closest_time` (28:30)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L32-L34" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:closest_wavelength` (32:34)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L36-L79" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:extract_time` (36:79)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L81-L126" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:extract_wavelength` (81:126)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L157-L177" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:interpolate_time` (157:177)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L228-L233" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:__add__` (228:233)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L235-L240" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:__sub__` (235:240)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L243-L251" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:to_dict` (243:251)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L254-L260" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:from_dict` (254:260)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L263-L290" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:plot` (263:290)</a>
+
+
+### Chromatogram
+The Chromatogram component extends Data2D and provides a high-level interface for processing a single chromatogram. It encapsulates the raw data, detected peaks, and metadata like sample and blank paths. This component orchestrates various processing steps including baseline correction, peak finding, and deconvolution, and offers methods to calculate peak area percentages and integrals.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram` (27:579)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L42-L98" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:__init__` (42:98)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L312-L349" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_area_percent` (312:349)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L351-L368" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_integrals` (351:368)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L370-L399" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_relative_integrals` (370:399)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L476-L484" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:to_dict` (476:484)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L487-L508" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:from_dict` (487:508)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L511-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:plot` (511:579)</a>
+
+
+### PeakRepresentation
+The PeakRepresentation component encompasses both simple detected peaks (Peak) and peaks that have been further analyzed and broken down into individual chemical components (DeconvolvedPeak). It stores information about peak boundaries, height, prominence, and for deconvolved peaks, includes deconvolution metrics and a list of associated Component objects.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L9-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak` (9:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L51-L53" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak:to_dict` (51:53)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L56-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak:from_dict` (56:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L11-L142" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak` (11:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L26-L74" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:__init__` (26:74)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L76-L112" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:merge_same_components` (76:112)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L114-L123" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:to_dict` (114:123)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L126-L142" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:from_dict` (126:142)</a>
+
+
+### Component
+The Component component represents a single chemical entity identified within a deconvolved peak. It stores the concentration profile, spectrum, elution time, integral, and a unique compound ID if assigned. This component is a building block for defining larger chemical compounds.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L10-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component` (10:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L51-L56" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component:to_dict` (51:56)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L59-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component:from_dict` (59:73)</a>
+
+
+### Compound
+The Compound component represents a distinct chemical compound, which can be derived by clustering similar Component objects across multiple chromatograms. It stores the averaged elution time, spectrum, name, and concentration factors, providing a consolidated view of a chemical species.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L12-L94" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound` (12:94)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L69-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound:to_dict` (69:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L76-L94" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound:from_dict` (76:94)</a>
+
+
+### MoccaDataset
+The MoccaDataset component serves as the central manager for a collection of Chromatogram objects and the Compounds identified within them. It orchestrates the entire data processing pipeline, including wavelength cropping, baseline correction, peak picking, deconvolution, and component clustering. It also provides high-level data analysis functionalities such as calculating area percentages and concentrations across the dataset.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L20-L804" target="_blank" rel="noopener noreferrer">`mocca2.dataset.dataset.MoccaDataset` (20:804)</a>
+
+
+### DataParsers
+The DataParsers component is a collection of utility functions responsible for reading and parsing raw chromatographic data files from various instrument-specific formats (e.g., Chemstation, Labsolutions, Empower, Masslynx). Its primary role is to convert these raw files into the standardized Data2D object format for further processing within the MOCCA system.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/chemstation.py#L6-L20" target="_blank" rel="noopener noreferrer">`mocca2.parsers.chemstation.parse_chemstation` (6:20)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/labsolutions.py#L5-L17" target="_blank" rel="noopener noreferrer">`mocca2.parsers.labsolutions.parse_labsolutions` (5:17)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/empower.py#L6-L30" target="_blank" rel="noopener noreferrer">`mocca2.parsers.empower.parse_empower` (6:30)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/masslynx.py#L8-L17" target="_blank" rel="noopener noreferrer">`mocca2.parsers.masslynx.parse_masslynx` (8:17)</a>
+
+
+### PeakProcessing
+The PeakProcessing component encapsulates the algorithms and logic for identifying, refining, and manipulating peaks within 1D chromatographic data. This includes initial peak detection, expanding peak borders to the baseline, merging overlapping peaks, and splitting complex merged peaks into simpler ones.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/find_peaks.py#L104-L134" target="_blank" rel="noopener noreferrer">`mocca2.peaks.find_peaks._initial_peak_picking` (104:134)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/split.py#L35-L85" target="_blank" rel="noopener noreferrer">`mocca2.peaks.split._split_peak` (35:85)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/merge_overlapping.py#L49-L60" target="_blank" rel="noopener noreferrer">`mocca2.peaks.merge_overlapping._merge_two_peaks` (49:60)</a>
+
+
+### Clustering
+The Clustering component is responsible for grouping similar Component objects, which represent individual chemical entities, into larger, more generalized Compound objects. This process involves applying similarity criteria to identify and average components that are likely to belong to the same chemical compound across different chromatograms.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/clustering/cluster_components.py#L10-L85" target="_blank" rel="noopener noreferrer">`mocca2.clustering.cluster_components.cluster_components` (10:85)</a>
+
+
+### Serialization
+The Serialization component provides a utility for converting complex Python objects, including NumPy arrays and Pandas DataFrames, into a dictionary format. This enables the persistence and reconstruction of MOCCA's data structures, facilitating saving and loading of processed data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/serializing.py#L5-L28" target="_blank" rel="noopener noreferrer">`mocca2.serializing.dict_encoder` (5:28)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Ingestion.md
+++ b/.codeboarding/Data Ingestion.md
@@ -1,0 +1,85 @@
+```mermaid
+graph LR
+    Data_Format_Parsers["Data Format Parsers"]
+    2D_Data_Model["2D Data Model"]
+    Chromatogram_Processing["Chromatogram Processing"]
+    Example_Data_Downloader["Example Data Downloader"]
+    Example_Data_Loaders["Example Data Loaders"]
+    Data_Format_Parsers -- "produces" --> 2D_Data_Model
+    Chromatogram_Processing -- "extends" --> 2D_Data_Model
+    Chromatogram_Processing -- "utilizes" --> Data_Format_Parsers
+    Example_Data_Loaders -- "depends on" --> Example_Data_Downloader
+    Example_Data_Loaders -- "instantiates" --> Chromatogram_Processing
+    Example_Data_Loaders -- "instantiates" --> 2D_Data_Model
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph describes the Data Ingestion subsystem, which is responsible for parsing raw chromatographic data from various instrument-specific formats into internal Core Data Structures. It also provides access to example datasets for testing and demonstration.
+
+### Data Format Parsers
+This component is responsible for parsing various proprietary raw chromatographic data formats (Empower, Chemstation, LabSolutions, MassLynx) into a standardized Data2D object. It provides a unified interface `load_data2d` to automatically detect and parse the file format.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/chemstation.py#L6-L20" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.chemstation:parse_chemstation` (6:20)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/labsolutions.py#L5-L17" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.labsolutions:parse_labsolutions` (5:17)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/empower.py#L6-L30" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.empower:parse_empower` (6:30)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/masslynx.py#L8-L17" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.masslynx:parse_masslynx` (8:17)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/wrapper.py#L10-L69" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.wrapper:load_data2d` (10:69)</a>
+
+
+### 2D Data Model
+This component defines the `Data2D` class, which is the fundamental data structure for representing 2D chromatographic data (time, wavelength, and absorbance). It provides methods for data manipulation such as extraction, interpolation, and basic plotting.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d:Data2D` (13:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L157-L177" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d:Data2D.interpolate_time` (157:177)</a>
+
+
+### Chromatogram Processing
+This component extends the `Data2D` model to `Chromatogram`, adding functionalities specific to chromatogram analysis, including baseline correction, peak finding, and peak deconvolution. It also handles loading sample and blank data, potentially subtracting the blank.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram:Chromatogram` (27:579)</a>
+
+
+### Example Data Downloader
+This component manages the downloading and unpacking of example chromatographic datasets from a remote repository. It ensures that the necessary data is available locally for demonstrations and testing.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L24-L44" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:download_data` (24:44)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L47-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:unpack_data` (47:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L10-L12" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:_example_data_path` (10:12)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L15-L16" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:_download_file` (15:16)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L19-L21" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:_extract_bz2` (19:21)</a>
+
+
+### Example Data Loaders
+This component provides specific functions to load various pre-defined example chromatograms and datasets, often performing initial processing like blank subtraction or time interpolation, making them ready for analysis. It depends on the Example Data Downloader to ensure data availability.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L13-L20" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:check_data_needs_downloading` (13:20)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L23-L36" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_1` (23:36)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L39-L52" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_2` (39:52)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L55-L68" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_3` (55:68)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L71-L168" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:knoevenagel_calibration` (71:168)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L171-L264" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:knoevenagel` (171:264)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L267-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:cyanation` (267:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L324-L338" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:benzaldehyde` (324:338)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L341-L423" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:diterpene_esters` (341:423)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Dataset Management & Analysis.md
+++ b/.codeboarding/Dataset Management & Analysis.md
@@ -1,0 +1,88 @@
+```mermaid
+graph LR
+    Data_Models["Data Models"]
+    Dataset_Management["Dataset Management"]
+    Clustering_Algorithms["Clustering Algorithms"]
+    Serialization_Utilities["Serialization Utilities"]
+    Mathematical_Utilities["Mathematical Utilities"]
+    Dataset_Management -- "manages" --> Data_Models
+    Dataset_Management -- "processes" --> Data_Models
+    Dataset_Management -- "invokes" --> Clustering_Algorithms
+    Dataset_Management -- "utilizes" --> Mathematical_Utilities
+    Dataset_Management -- "uses" --> Serialization_Utilities
+    Clustering_Algorithms -- "operates on" --> Data_Models
+    Clustering_Algorithms -- "generates" --> Data_Models
+    Clustering_Algorithms -- "utilizes" --> Mathematical_Utilities
+    Data_Models -- "supports" --> Serialization_Utilities
+    Serialization_Utilities -- "serializes" --> Data_Models
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This component overview details the Dataset Management & Analysis subsystem of the MOCCA project. It focuses on how chemical data, represented by various data models, is managed, processed, and analyzed. The core functionality revolves around the Dataset Management component, which orchestrates operations like data loading, applying processing settings, and invoking specialized algorithms for tasks such as clustering, all while leveraging utility components for serialization and mathematical operations.
+
+### Data Models
+This component encompasses the fundamental data structures used throughout the MOCCA system, including Chromatogram, DeconvolvedPeak, Peak, Component, Compound, and Data2D. These classes define the attributes and basic behaviors of the chemical data being processed, such as conversion to and from dictionary representations for serialization.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram` (27:579)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L11-L142" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak` (11:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L9-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak` (9:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L10-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component` (10:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L12-L94" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound` (12:94)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D` (13:321)</a>
+
+
+### Dataset Management
+This component is responsible for managing collections of chromatograms and their associated processing settings. The MoccaDataset class provides functionalities for adding chromatograms, processing them through various steps like baseline correction, peak picking, deconvolution, and compound clustering, and also for retrieving processed data like area percentages and concentrations. ProcessingSettings defines the parameters for these operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L20-L804" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset` (20:804)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L10-L90" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings` (10:90)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L56-L59" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:from_yaml` (56:59)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L61-L63" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:to_dict` (61:63)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L66-L90" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:from_dict` (66:90)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L47-L55" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:__init__` (47:55)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L57-L119" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:add_chromatogram` (57:119)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L177-L262" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:_name_compounds` (177:262)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L264-L480" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:process_all` (264:480)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L755-L767" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:to_dict` (755:767)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L770-L804" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:from_dict` (770:804)</a>
+
+
+### Clustering Algorithms
+This component provides the core logic for clustering individual peak components into averaged compounds. The `cluster_components` function takes a list of components and a similarity function to group them, ultimately assigning compound IDs and creating Compound objects.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/clustering/cluster_components.py#L10-L85" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.clustering.cluster_components` (10:85)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/clustering/cluster_components.py#L10-L85" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.clustering.cluster_components:cluster_components` (10:85)</a>
+
+
+### Serialization Utilities
+This component provides utility functions for converting complex Python objects into dictionary representations, facilitating their serialization and deserialization. The `dict_encoder` function is a key part of this process, ensuring that data models can be easily stored and retrieved.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/serializing.py#L5-L28" target="_blank" rel="noopener noreferrer">`mocca2.serializing.dict_encoder` (5:28)</a>
+
+
+### Mathematical Utilities
+This component provides common mathematical functions used across the MOCCA system, such as cosine similarity. These utilities support various analytical tasks, including the comparison of spectra during deconvolution and clustering.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/math.py#L8-L18" target="_blank" rel="noopener noreferrer">`mocca2.math.cosine_similarity` (8:18)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Serialization Utilities.md
+++ b/.codeboarding/Serialization Utilities.md
@@ -1,0 +1,86 @@
+```mermaid
+graph LR
+    Serialization_Utilities["Serialization Utilities"]
+    CoreDataModels["CoreDataModels"]
+    ChromatogramProcessingUnit["ChromatogramProcessingUnit"]
+    ChemicalCompoundRegistry["ChemicalCompoundRegistry"]
+    ProcessingSettingsManager["ProcessingSettingsManager"]
+    DatasetOrchestrator["DatasetOrchestrator"]
+    CoreDataModels -- "is serialized by" --> Serialization_Utilities
+    ChromatogramProcessingUnit -- "is serialized by" --> Serialization_Utilities
+    ChemicalCompoundRegistry -- "is serialized by" --> Serialization_Utilities
+    ProcessingSettingsManager -- "is serialized by" --> Serialization_Utilities
+    DatasetOrchestrator -- "is serialized by" --> Serialization_Utilities
+    DatasetOrchestrator -- "manages" --> ChromatogramProcessingUnit
+    DatasetOrchestrator -- "configures with" --> ProcessingSettingsManager
+    DatasetOrchestrator -- "integrates" --> ChemicalCompoundRegistry
+    CoreDataModels -- "references" --> ChemicalCompoundRegistry
+    ChromatogramProcessingUnit -- "depends on" --> CoreDataModels
+    DatasetOrchestrator -- "depends on" --> ProcessingSettingsManager
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This architecture describes the core components of the MOCCA2 project, focusing on data processing and management. The `DatasetOrchestrator` acts as the central hub, managing `ChromatogramProcessingUnit` for individual chromatogram analysis, integrating `ChemicalCompoundRegistry` for compound definitions, and applying settings from `ProcessingSettingsManager`. Fundamental data structures are defined by `CoreDataModels`, which are processed by `ChromatogramProcessingUnit` and can reference `ChemicalCompoundRegistry`. All these key components, including `CoreDataModels`, `ChromatogramProcessingUnit`, `ChemicalCompoundRegistry`, `ProcessingSettingsManager`, and `DatasetOrchestrator`, rely on `Serialization Utilities` for converting their complex Python objects into dictionary representations, enabling persistence and data exchange.
+
+### Serialization Utilities
+Provides generic utility functions for converting complex Python objects into dictionary representations, enabling their serialization and deserialization for persistence or data exchange.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/serializing.py#L5-L28" target="_blank" rel="noopener noreferrer">`mocca2.serializing:dict_encoder` (5:28)</a>
+
+
+### CoreDataModels
+Defines the fundamental data structures for representing 2D chromatographic data (Data2D), individual peaks (Peak), deconvolved peak components (DeconvolvedPeak), and single chemical components (Component).
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`mocca2.classes.data2d.Data2D` (13:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L9-L67" target="_blank" rel="noopener noreferrer">`mocca2.classes.peak.Peak` (9:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L11-L142" target="_blank" rel="noopener noreferrer">`mocca2.classes.deconvolved_peak.DeconvolvedPeak` (11:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L10-L73" target="_blank" rel="noopener noreferrer">`mocca2.classes.component.Component` (10:73)</a>
+
+
+### ChromatogramProcessingUnit
+Encapsulates the logic for processing a single chromatogram, including baseline correction, peak finding, and deconvolution. It operates on and produces instances of CoreDataModels.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`mocca2.classes.chromatogram.Chromatogram` (27:579)</a>
+
+
+### ChemicalCompoundRegistry
+Manages the definition and properties of chemical compounds, including their spectral characteristics and concentration factors.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L12-L94" target="_blank" rel="noopener noreferrer">`mocca2.classes.compound.Compound` (12:94)</a>
+
+
+### ProcessingSettingsManager
+Stores and manages all the configurable parameters and settings required for the automated processing of chromatographic data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L10-L90" target="_blank" rel="noopener noreferrer">`mocca2.dataset.settings.ProcessingSettings` (10:90)</a>
+
+
+### DatasetOrchestrator
+This is the central component that manages a collection of chromatograms and compounds. It orchestrates the entire data processing pipeline by applying settings from ProcessingSettingsManager and utilizing ChromatogramProcessingUnit for individual chromatogram analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L20-L804" target="_blank" rel="noopener noreferrer">`mocca2.dataset.dataset.MoccaDataset` (20:804)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,157 @@
+```mermaid
+graph LR
+    Core_Data_Structures["Core Data Structures"]
+    Data_Ingestion["Data Ingestion"]
+    Chromatogram_Processing["Chromatogram Processing"]
+    Dataset_Management_Analysis["Dataset Management & Analysis"]
+    Serialization_Utilities["Serialization Utilities"]
+    Data_Ingestion -- "creates" --> Core_Data_Structures
+    Chromatogram_Processing -- "operates on" --> Core_Data_Structures
+    Dataset_Management_Analysis -- "manages" --> Core_Data_Structures
+    Dataset_Management_Analysis -- "orchestrates" --> Chromatogram_Processing
+    Core_Data_Structures -- "uses" --> Serialization_Utilities
+    Dataset_Management_Analysis -- "uses" --> Serialization_Utilities
+    click Core_Data_Structures href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/Core Data Structures.md" "Details"
+    click Data_Ingestion href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/Data Ingestion.md" "Details"
+    click Chromatogram_Processing href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/Chromatogram Processing.md" "Details"
+    click Dataset_Management_Analysis href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/Dataset Management & Analysis.md" "Details"
+    click Serialization_Utilities href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/Serialization Utilities.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The MOCCA project provides a comprehensive framework for chromatographic data analysis. Its main flow involves ingesting raw instrument data into well-defined core data structures. These structures are then subjected to a series of processing steps, including baseline correction, peak detection, and deconvolution, orchestrated by the Chromatogram Processing component. For multi-sample analysis, the Dataset Management & Analysis component handles collections of processed chromatograms, applies global settings, and performs higher-level tasks like component clustering. Throughout the system, a dedicated Serialization Utilities component ensures that complex data objects can be efficiently stored and retrieved.
+
+### Core Data Structures
+Defines the fundamental data structures for representing 2D chromatographic data, individual chromatograms, and derived entities like peaks, deconvolved peaks, components, and compounds. These structures serve as the primary data carriers throughout the MOCCA system.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L13-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D` (13:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L28-L30" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:closest_time` (28:30)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L32-L34" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:closest_wavelength` (32:34)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L36-L79" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:extract_time` (36:79)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L81-L126" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:extract_wavelength` (81:126)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L157-L177" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:interpolate_time` (157:177)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L228-L233" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:__add__` (228:233)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L235-L240" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:__sub__` (235:240)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L243-L251" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:to_dict` (243:251)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L254-L260" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:from_dict` (254:260)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/data2d.py#L263-L290" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.data2d.Data2D:plot` (263:290)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L27-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram` (27:579)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L42-L98" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:__init__` (42:98)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L312-L349" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_area_percent` (312:349)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L351-L368" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_integrals` (351:368)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L370-L399" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:get_relative_integrals` (370:399)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L476-L484" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:to_dict` (476:484)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L487-L508" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:from_dict` (487:508)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L511-L579" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:plot` (511:579)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L9-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak` (9:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L51-L53" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak:to_dict` (51:53)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/peak.py#L56-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.peak.Peak:from_dict` (56:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L11-L142" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak` (11:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L26-L74" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:__init__` (26:74)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L76-L112" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:merge_same_components` (76:112)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L114-L123" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:to_dict` (114:123)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/deconvolved_peak.py#L126-L142" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.deconvolved_peak.DeconvolvedPeak:from_dict` (126:142)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L10-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component` (10:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L51-L56" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component:to_dict` (51:56)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/component.py#L59-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.component.Component:from_dict` (59:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L12-L94" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound` (12:94)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L69-L73" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound:to_dict` (69:73)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/compound.py#L76-L94" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.compound.Compound:from_dict` (76:94)</a>
+
+
+### Data Ingestion
+Responsible for parsing raw chromatographic data from various instrument-specific formats (e.g., Chemstation, Labsolutions) into the internal Core Data Structures. It also provides access to example datasets for testing and demonstration.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/chemstation.py#L6-L20" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.chemstation:parse_chemstation` (6:20)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/labsolutions.py#L5-L17" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.labsolutions:parse_labsolutions` (5:17)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/empower.py#L6-L30" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.empower:parse_empower` (6:30)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/masslynx.py#L8-L17" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.masslynx:parse_masslynx` (8:17)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/parsers/wrapper.py#L10-L69" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.parsers.wrapper:load_data2d` (10:69)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L24-L44" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:download_data` (24:44)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/downloader.py#L47-L67" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.downloader:unpack_data` (47:67)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L13-L20" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:check_data_needs_downloading` (13:20)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L23-L36" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_1` (23:36)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L39-L52" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_2` (39:52)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L55-L68" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:example_3` (55:68)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L71-L168" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:knoevenagel_calibration` (71:168)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L171-L264" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:knoevenagel` (171:264)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L267-L321" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:cyanation` (267:321)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L324-L338" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:benzaldehyde` (324:338)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/example_data/loaders.py#L341-L423" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.example_data.loaders:diterpene_esters` (341:423)</a>
+
+
+### Chromatogram Processing
+Provides the core functionalities for processing individual chromatograms, including baseline correction, peak detection (finding, splitting, merging), and deconvolution of overlapping peaks using various algorithms and peak models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L100-L145" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:correct_baseline` (100:145)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L147-L229" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:find_peaks` (147:229)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L231-L295" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:deconvolve_peaks` (231:295)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/classes/chromatogram.py#L401-L473" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.classes.chromatogram.Chromatogram:refine_peaks` (401:473)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/arpls.py#L17-L147" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.baseline.arpls:arpls` (17:147)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/asls.py#L15-L129" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.baseline.asls:asls` (15:129)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/baseline/wrapper.py#L16-L98" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.baseline.wrapper:estimate_baseline` (16:98)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/find_peaks.py#L13-L101" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.find_peaks:find_peaks` (13:101)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/find_peaks.py#L104-L134" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.find_peaks:_initial_peak_picking` (104:134)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/split.py#L8-L33" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.split:split_peaks` (8:33)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/split.py#L35-L85" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.split:_split_peak` (35:85)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/merge_overlapping.py#L7-L40" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.merge_overlapping:merge_overlapping_peaks` (7:40)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/peaks/merge_overlapping.py#L49-L60" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.peaks.merge_overlapping:_merge_two_peaks` (49:60)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/deconvolve.py#L11-L74" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.deconvolve:deconvolve_adaptive` (11:74)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/deconvolve.py#L77-L126" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.deconvolve:deconvolve_fixed` (77:126)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/fit_peak_model.py#L20-L264" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.fit_peak_model:fit_peak_model` (20:264)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/guess_spectra.py#L11-L54" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.guess_spectra:guess_spectra` (11:54)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/guess_spectra.py#L57-L69" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.guess_spectra:_get_similarity_matrix` (57:69)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/alternating_lstsq.py#L12-L105" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.alternating_lstsq:alternating_lstsq` (12:105)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/nonnegative_lstsq.py#L11-L53" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.nonnegative_lstsq:concentrations_from_spectra` (11:53)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/nonnegative_lstsq.py#L56-L83" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.nonnegative_lstsq:spectra_from_concentrations` (56:83)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L17-L21" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.PeakModel:__call__` (17:21)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L246-L266" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.Bemg:val` (246:266)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L268-L310" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.Bemg:grad` (268:310)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L80-L115" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.BiGaussian` (80:115)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L118-L167" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.BiGaussianTailing` (118:167)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/deconvolution/peak_models.py#L170-L230" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.deconvolution.peak_models.FraserSuzuki` (170:230)</a>
+
+
+### Dataset Management & Analysis
+Manages collections of Chromatogram objects, applies processing settings across multiple datasets, and performs higher-level analytical tasks such as clustering components to identify common compounds.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L20-L804" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset` (20:804)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L10-L90" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings` (10:90)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L56-L59" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:from_yaml` (56:59)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L61-L63" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:to_dict` (61:63)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/settings.py#L66-L90" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.settings.ProcessingSettings:from_dict` (66:90)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L47-L55" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:__init__` (47:55)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L57-L119" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:add_chromatogram` (57:119)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L177-L262" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:_name_compounds` (177:262)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L264-L480" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:process_all` (264:480)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L755-L767" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:to_dict` (755:767)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/dataset/dataset.py#L770-L804" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.dataset.dataset.MoccaDataset:from_dict` (770:804)</a>
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/clustering/cluster_components.py#L10-L85" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.clustering.cluster_components:cluster_components` (10:85)</a>
+
+
+### Serialization Utilities
+Provides generic utility functions for converting complex Python objects into dictionary representations, enabling their serialization and deserialization for persistence or data exchange.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/MOCCA/blob/master/src/mocca2/serializing.py#L5-L28" target="_blank" rel="noopener noreferrer">`MOCCA.src.mocca2.serializing:dict_encoder` (5:28)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the MOCCA's codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/MOCCA/on_boarding.md

The idea of these diagrams are to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about diagram first documentation for on-boarding and if it fits in your existing on-boarding processes.

We are also developing a github action which can generate the documentation for every commit in main. It will be available soon so let me know if that sounds interesting!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.

I have opened also the PR's with diagrams for few of your other open source projects :)